### PR TITLE
Add clustering support to Table resources

### DIFF
--- a/src/bq_test_kit/bq_dsl/bq_resources/clustering.py
+++ b/src/bq_test_kit/bq_dsl/bq_resources/clustering.py
@@ -1,0 +1,29 @@
+from copy import deepcopy
+from typing import List
+
+from google.cloud.bigquery.table import Table as BQTable
+
+
+class Clustering:
+    """
+    Defines the fields that a table should be clustered by.
+
+    https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#Clustering
+    """
+    def __init__(self, *fields: str):
+        self.fields: List[str]
+        if not fields:
+            self.fields = []
+        else:
+            self.fields = fields
+
+    def apply(self, bq_resource: BQTable) -> BQTable:
+        if self.fields:
+            new_resource = deepcopy(bq_resource)
+            new_resource.clustering_fields = self.fields
+            return new_resource
+        else:
+            return bq_resource
+
+    def __repr__(self):
+        return str(self.fields)

--- a/tests/ut/bq_test_kit/bq_dsl/bq_resources/test_clustering.py
+++ b/tests/ut/bq_test_kit/bq_dsl/bq_resources/test_clustering.py
@@ -1,0 +1,15 @@
+from google.cloud.bigquery.table import Table as BQTable
+
+from bq_test_kit.bq_dsl.bq_resources.clustering import Clustering
+
+
+def test_apply_clustering():
+    table = BQTable("project.dataset.table")
+    assert table.clustering_fields is None
+    table = Clustering().apply(table)
+    # if you try to enable clustering with an empty field list, you'll get a BQ API error
+    assert table.clustering_fields is None
+    table = Clustering("cluster_field").apply(table)
+    assert table.clustering_fields == ["cluster_field"]
+    table = Clustering("field_a", "field_b").apply(table)
+    assert table.clustering_fields == ["field_a", "field_b"]


### PR DESCRIPTION
Bigquery tables can be clustered by certain fields, which helps with query performance.